### PR TITLE
Rolled back the deletion of AP in favor of deprecation

### DIFF
--- a/trusona-sdk-http/src/main/java/com/trusona/sdk/http/environment/ApProdEnvironment.java
+++ b/trusona-sdk-http/src/main/java/com/trusona/sdk/http/environment/ApProdEnvironment.java
@@ -1,0 +1,17 @@
+package com.trusona.sdk.http.environment;
+
+import okhttp3.logging.HttpLoggingInterceptor;
+
+@Deprecated
+public class ApProdEnvironment implements Environment {
+  private static final String ENDPOINT_URL = "https://api.ap.trusona.net";
+  @Override
+  public HttpLoggingInterceptor.Level getLoggingLevel() {
+    return HttpLoggingInterceptor.Level.NONE;
+  }
+
+  @Override
+  public String getEndpointUrl() {
+    return ENDPOINT_URL;
+  }
+}

--- a/trusona-sdk-http/src/main/java/com/trusona/sdk/http/environment/ApUatEnvironment.java
+++ b/trusona-sdk-http/src/main/java/com/trusona/sdk/http/environment/ApUatEnvironment.java
@@ -1,0 +1,17 @@
+package com.trusona.sdk.http.environment;
+
+import okhttp3.logging.HttpLoggingInterceptor;
+
+@Deprecated
+public class ApUatEnvironment implements Environment {
+  private static final String ENDPOINT_URL = "https://api.staging.ap.trusona.net";
+  @Override
+  public HttpLoggingInterceptor.Level getLoggingLevel() {
+    return HttpLoggingInterceptor.Level.BASIC;
+  }
+
+  @Override
+  public String getEndpointUrl() {
+    return ENDPOINT_URL;
+  }
+}

--- a/trusona-sdk-http/src/test/groovy/com/trusona/sdk/http/environment/ApProdEnvironmentSpec.groovy
+++ b/trusona-sdk-http/src/test/groovy/com/trusona/sdk/http/environment/ApProdEnvironmentSpec.groovy
@@ -1,0 +1,29 @@
+package com.trusona.sdk.http.environment
+
+import okhttp3.logging.HttpLoggingInterceptor
+import spock.lang.Specification
+
+class ApProdEnvironmentSpec extends Specification {
+
+  ApProdEnvironment sut
+
+  def setup() {
+    sut = new ApProdEnvironment()
+  }
+
+  def "getLoggingLevel should return NONE"() {
+    when:
+    def res = sut.getLoggingLevel()
+
+    then:
+    res == HttpLoggingInterceptor.Level.NONE
+  }
+
+  def "getEndpointUrl should return the AP prod url"() {
+    when:
+    def res = sut.getEndpointUrl()
+
+    then:
+    res == "https://api.ap.trusona.net"
+  }
+}

--- a/trusona-sdk-http/src/test/groovy/com/trusona/sdk/http/environment/ApUatEnvironmentSpec.groovy
+++ b/trusona-sdk-http/src/test/groovy/com/trusona/sdk/http/environment/ApUatEnvironmentSpec.groovy
@@ -1,0 +1,30 @@
+package com.trusona.sdk.http.environment
+
+import okhttp3.logging.HttpLoggingInterceptor
+import spock.lang.Specification
+
+class ApUatEnvironmentSpec extends Specification {
+
+  ApUatEnvironment sut
+
+  def setup() {
+    sut = new ApUatEnvironment()
+  }
+  def "getLoggingLevel should return BASIC"() {
+    when:
+    def res = sut.getLoggingLevel()
+
+    then:
+    res == HttpLoggingInterceptor.Level.BASIC
+  }
+
+
+  def "getEndpointUrl should return the AP UAT url"() {
+    when:
+    def res = sut.getEndpointUrl()
+
+    then:
+    res == "https://api.staging.ap.trusona.net"
+  }
+}
+

--- a/trusona-sdk/src/main/java/com/trusona/sdk/EnvironmentFactory.java
+++ b/trusona-sdk/src/main/java/com/trusona/sdk/EnvironmentFactory.java
@@ -12,6 +12,10 @@ public class EnvironmentFactory {
         return new ProdEnvironment();
       case UAT:
         return new UatEnvironment();
+      case AP_PRODUCTION:
+        return new ApProdEnvironment();
+      case AP_UAT:
+        return new ApUatEnvironment();
       case EU_PRODUCTION:
         return new EuProdEnvironment();
       case EU_UAT:

--- a/trusona-sdk/src/main/java/com/trusona/sdk/TrusonaEnvironment.java
+++ b/trusona-sdk/src/main/java/com/trusona/sdk/TrusonaEnvironment.java
@@ -7,6 +7,10 @@ package com.trusona.sdk;
 public enum TrusonaEnvironment {
   PRODUCTION,
   UAT,
+  @Deprecated
+  AP_UAT,
+  @Deprecated
+  AP_PRODUCTION,
   EU_PRODUCTION,
   EU_UAT,
   TEST_VERIFY,

--- a/trusona-sdk/src/test/groovy/com/trusona/sdk/EnvironmentFactorySpec.groovy
+++ b/trusona-sdk/src/test/groovy/com/trusona/sdk/EnvironmentFactorySpec.groovy
@@ -15,6 +15,8 @@ class EnvironmentFactorySpec extends Specification {
     env           | envClass
     PRODUCTION    | new ProdEnvironment()
     UAT           | new UatEnvironment()
+    AP_PRODUCTION | new ApProdEnvironment()
+    AP_UAT        | new ApUatEnvironment()
     EU_PRODUCTION | new EuProdEnvironment()
     EU_UAT        | new EuUatEnvironment()
     TEST_VERIFY   | new TestVerifyEnvironment()


### PR DESCRIPTION
After discussion with Clayton and plopping version `4.2.1-SNAPSHOT` into the Gateway project, I realized that going full deletion on AP was too heavy handed. 

This could be a chance to follow true Semver (thanks to Nikolas for suggestion it during the previous review as well..):
- Deprecate the AP environments in a **MINOR** release of the SDK
- Update Gateway with the **MINOR** release of the SDK
- Clean up Gateway references to all deprecated methods (if there's anything other than the AP environments that have been deprecated) 
- Release the Gateway (most likely)
- Delete all the deprecations for a **MAJOR** release of the SDK
- Update Gateway with the **MAJOR** release of the SDK